### PR TITLE
Check if defaults are set, even if they're falsey.

### DIFF
--- a/buddy_config.py
+++ b/buddy_config.py
@@ -62,7 +62,7 @@ class Config:
             except KeyError:
                 raise ConfigurationError(setting_func.var_name, setting_func.__name__)
             else:
-                if not res:
+                if not res and setting_func.var_name not in self._defaults:
                     raise ConfigurationError(
                         setting_func.var_name, setting_func.__name__
                     )


### PR DESCRIPTION
In [Sentry](https://develop.sentry.dev/sdk/overview/) you can define its server URL (or `DSN`) as empty as a sensible default or when you want to disable it (e.g. for tests that don't have the environment variables mocked). From the docs:

> The SDK should accept an empty DSN as valid configuration.


I don't know if this is the most elegant solution but I just wanted to allow for an empty string as a default for `SENTRY_DSN` (check [here](https://github.com/launchpadrecruits/predict-audio-service/pull/28/files#diff-1f9f743421417fb2794c88447083a031R19) and I think this might work.